### PR TITLE
Address Barry's comment in the BOF

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -38,9 +38,9 @@
 
 ## ASDF
 
-  The objective of the ASDF WG will be to work with OneDM and its
-  contributing organizations and develop SDF to an IETF-quality
-  specification for Thing Interaction and Data Modelling.  On the way
+  The objective of the ASDF WG is to develop SDF to an IETF-quality
+  specification for Thing Interaction and Data Modelling, working with
+  experts from OneDM and its contributing organizations.  On the way
   to that specification, further functionality requirements will be
   addressed that emerge in the usage of SDF for model harmonization.
 


### PR DESCRIPTION
During the BOF, @barryleiba made a comment that our basis of cooperation with OneDM and contributing SDOs should be people, not liaison statements.